### PR TITLE
Add support for "activate" and "sender" terminal-notifier options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ By default it will run the `nc:finished` task after your `deploy` or `deploy:mig
 after `your:task`, `nc:finished`
 ```
 
+Terminal.app is opened when the notification is clicked. To use an alternative terminal set `:nc_terminal` to the bundle identifier e.g. `set :nc_terminal, 'com.googlecode.iterm2'` for iTerm2.
+
 ## Contributors
 
 - [Kir Shatrov](https://github.com/kirs/)

--- a/lib/capistrano-nc/tasks/nc.rake
+++ b/lib/capistrano-nc/tasks/nc.rake
@@ -22,9 +22,18 @@ namespace :nc do
         "#{application} to #{announced_stage}"
       end
 
-      TerminalNotifier.notify(announcement, title: "Capistrano")
+      terminal = fetch(:nc_terminal, 'com.apple.Terminal')
+      TerminalNotifier.notify(announcement, title: "Capistrano", sender: terminal, activate: terminal)
     end
   end
 end
 
 after 'deploy:finished', 'nc:finished'
+
+namespace :load do
+  task :defaults do
+
+    set :nc_terminal, 'com.apple.Terminal'
+
+  end
+end


### PR DESCRIPTION
There is an issue with terminal notifier and 10.9 https://github.com/alloy/terminal-notifier/issues/63

Without specifying a `sender` I don't get any notifications under OS X 10.9.1
I also added the `activate` option to define what gets _opened_ when the notifications is clicked.

I also created a setting (with default of `com.apple.Terminal`) to define the server and application to be activated via bundle identifier: `set :nc_terminal, 'foo'`

For me this gives me notifications as expected.
