### PR TITLE
update terminal-notifier dep

### DIFF
--- a/capistrano-nc.gemspec
+++ b/capistrano-nc.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
 
   gem.licenses      = %w(MIT)
 
-  gem.add_dependency 'terminal-notifier', '~> 1.5.1'
+  gem.add_dependency 'terminal-notifier', '~> 1.6'
   gem.add_dependency 'capistrano', '~> 3.0'
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
There are a couple of useful updates in the 1.6 version.
One is 10.10 (Yosemite) compatibility.
