### PR TITLE
Upgrade to terminal-notifier ~> 2.0 to fix hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 https://github.com/capistrano/notification-center/compare/v0.1.4...HEAD
 
 * Your contribution here!
+* [#9](https://github.com/capistrano/notification-center/pull/9): Update terminal-notifier dependency to ~> 2.0. This fixes a bug where capistrano-nc would hang forever waiting for the notification to dismiss.
 
 ## 0.1.4
 

--- a/capistrano-nc.gemspec
+++ b/capistrano-nc.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
 
   gem.licenses      = %w(MIT)
 
-  gem.add_dependency 'terminal-notifier', '~> 1.6'
+  gem.add_dependency 'terminal-notifier', '~> 2.0'
   gem.add_dependency 'capistrano', '~> 3.0'
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
This fixes a bug where capistrano-nc would hang forever waiting for the notification to dismiss, as discussed in #8.